### PR TITLE
fix: race condition that caused the online indicators to not work properly

### DIFF
--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -206,8 +206,16 @@ export default function ChatPanel({
             >
               {selectedUser && selectedUser.name ? selectedUser.name : "User"}
             </span>
-            <span className="text-xs font-bold text-[#39ff14]">
-              {selectedUser && selectedUser.status ? selectedUser.status : ""}
+            <span
+              className={`text-sm font-bold ${
+                selectedUser && selectedUser.status === "online"
+                  ? "text-[#39ff14]"
+                  : "text-gray-400"
+              }`}
+            >
+              {selectedUser && selectedUser.status === "online"
+                ? "online"
+                : "offline"}
             </span>
           </div>
           <ModeToggle />

--- a/frontend/src/components/chat/ModernNPMChat.tsx
+++ b/frontend/src/components/chat/ModernNPMChat.tsx
@@ -56,6 +56,13 @@ const ChatPanels: React.FC<{ currentUser: any }> = ({ currentUser }) => {
       unread: unseenMessages[u._id || u.id] || 0,
     }))
 
+  const currentSelectedUser = selectedUser
+    ? users.find(
+        (user: any) =>
+          (user._id || user.id) === (selectedUser._id || selectedUser.id),
+      ) || selectedUser
+    : null
+
   return (
     <div className="flex flex-col md:flex-row h-screen w-screen font-sans bg-gradient-to-br from-[#b39ddb]/40 via-white to-[#39ff14]/20 text-black relative overflow-hidden">
       {/* Sidebar */}
@@ -66,7 +73,7 @@ const ChatPanels: React.FC<{ currentUser: any }> = ({ currentUser }) => {
       >
         <ChatSidebar
           users={filteredUsers}
-          selectedUser={selectedUser || {}}
+          selectedUser={currentSelectedUser || {}}
           onUserSelect={handleUserClick}
           onProfile={() => {
             setProfileDraft({
@@ -90,7 +97,7 @@ const ChatPanels: React.FC<{ currentUser: any }> = ({ currentUser }) => {
           mobileView === "sidebar" ? "hidden md:flex" : ""
         }`}
       >
-        <ChatPanel selectedUser={selectedUser} onBack={handleBack} />
+        <ChatPanel selectedUser={currentSelectedUser} onBack={handleBack} />
         {loadingMessages && (
           <div className="p-4 text-center">Loading messages...</div>
         )}


### PR DESCRIPTION
Hello @ThePlator, this PR closes #55 

Changes made:
- Implemented real-time online/offline status updates for users in the chat list and chat header
- Added a reusable applyOnlineStatus helper to consistently update user statuses across components
- Modified the getOnlineUsers socket listener to ensure online status updates 
- Enhanced ChatPanel to display online/offline labels with color indicators (#39ff14 for online, gray for offline)
- Improved ModernNPMChat user selection logic to keep selectedUser in sync with updated status data

I tested the following:

- Verified that user list updates instantly when a user connects/disconnects
- Confirmed online/offline status updates in both sidebar and chat panel header
- Ensured unseen message counts remain intact after status updates
- This improves the real-time experience by ensuring user presence is always visible and accurate.

After Change:
<img width="1896" height="1168" alt="Screenshot 2025-08-10 at 3 51 34 PM" src="https://github.com/user-attachments/assets/f1f09f04-8c1f-4c53-8f60-f4bbb0a2ba39" />


Thank you!