### PR TITLE
fix: enhance styling for License and Privacy pages with dark mode support (#54)

### DIFF
--- a/frontend/src/app/license/page.tsx
+++ b/frontend/src/app/license/page.tsx
@@ -10,12 +10,16 @@ export default function LicensePage() {
   return (
     <div className="min-h-screen flex flex-col">
       <main className="flex-grow container mx-auto px-4 py-12 max-w-4xl">
-        <div className="bg-white p-8 rounded-lg shadow-lg border-2 border-black">
-          <h1 className="text-4xl font-bold mb-6 text-center">MIT License</h1>
+        <div className="bg-white dark:bg-zinc-900 p-8 rounded-lg shadow-lg border-2 border-black dark:border-zinc-700">
+          <h1 className="text-4xl font-bold mb-6 text-center text-black dark:text-white">
+            MIT License
+          </h1>
 
           <div className="mb-8">
-            <p className="mb-4">Copyright (c) 2025 NPMChat</p>
-            <p className="mb-4">
+            <p className="mb-4 text-black dark:text-zinc-200">
+              Copyright (c) 2025 NPMChat
+            </p>
+            <p className="mb-4 text-black dark:text-zinc-200">
               Permission is hereby granted, free of charge, to any person
               obtaining a copy of this software and associated documentation
               files (the "Software"), to deal in the Software without
@@ -41,18 +45,20 @@ export default function LicensePage() {
           </div>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">Attribution</h2>
-            <p className="mb-4">
+            <h2 className="text-2xl font-semibold mb-4 text-black dark:text-white">
+              Attribution
+            </h2>
+            <p className="mb-4 text-black dark:text-zinc-200">
               This project uses the following open source software and
               resources:
             </p>
-            <ul className="list-disc pl-6 space-y-2">
+            <ul className="list-disc pl-6 space-y-2 text-black dark:text-zinc-200">
               <li>
                 <a
                   href="https://nextjs.org/"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-blue-600 hover:underline"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
                 >
                   Next.js
                 </a>{" "}

--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -10,17 +10,19 @@ export default function PrivacyPage() {
   return (
     <div className="min-h-screen flex flex-col">
       <main className="flex-grow container mx-auto px-4 py-12 max-w-4xl">
-        <div className="bg-white p-8 rounded-lg shadow-lg border-2 border-black">
-          <h1 className="text-4xl font-bold mb-6 text-center">
+        <div className="bg-white dark:bg-zinc-900 p-8 rounded-lg shadow-lg border-2 border-black dark:border-zinc-700">
+          <h1 className="text-4xl font-bold mb-6 text-center text-black dark:text-white">
             Privacy Policy
           </h1>
-          <p className="mb-4">Last updated: August 1, 2025</p>
+          <p className="mb-4 text-black dark:text-zinc-200">
+            Last updated: August 1, 2025
+          </p>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">
+            <h2 className="text-2xl font-semibold mb-4 text-black dark:text-white">
               1. Information We Collect
             </h2>
-            <p className="mb-4">
+            <p className="mb-4 text-black dark:text-zinc-200">
               We collect information that you provide directly to us, such as
               when you create an account, update your profile, or communicate
               with us. This may include your name, email address, and any other
@@ -29,11 +31,13 @@ export default function PrivacyPage() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">
+            <h2 className="text-2xl font-semibold mb-4 text-black dark:text-white">
               2. How We Use Your Information
             </h2>
-            <p className="mb-4">We use the information we collect to:</p>
-            <ul className="list-disc pl-6 mb-4 space-y-2">
+            <p className="mb-4 text-black dark:text-zinc-200">
+              We use the information we collect to:
+            </p>
+            <ul className="list-disc pl-6 mb-4 space-y-2 text-black dark:text-zinc-200">
               <li>Provide, maintain, and improve our services</li>
               <li>Send you technical notices and support messages</li>
               <li>Respond to your comments, questions, and requests</li>
@@ -42,18 +46,20 @@ export default function PrivacyPage() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">
+            <h2 className="text-2xl font-semibold mb-4 text-black dark:text-white">
               3. Information Sharing
             </h2>
-            <p className="mb-4">
+            <p className="mb-4 text-black dark:text-zinc-200">
               We do not share your personal information with third parties
               except as described in this Privacy Policy or with your consent.
             </p>
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">4. Security</h2>
-            <p className="mb-4">
+            <h2 className="text-2xl font-semibold mb-4 text-black dark:text-white">
+              4. Security
+            </h2>
+            <p className="mb-4 text-black dark:text-zinc-200">
               We take reasonable measures to help protect your personal
               information from loss, theft, misuse, and unauthorized access,
               disclosure, alteration, and destruction.
@@ -61,10 +67,10 @@ export default function PrivacyPage() {
           </section>
 
           <section>
-            <h2 className="text-2xl font-semibold mb-4">
+            <h2 className="text-2xl font-semibold mb-4 text-black dark:text-white">
               5. Changes to This Policy
             </h2>
-            <p>
+            <p className="text-black dark:text-zinc-200">
               We may update this Privacy Policy from time to time. We will
               notify you of any changes by posting the new Privacy Policy on
               this page and updating the "Last updated" date.


### PR DESCRIPTION
Description

Summary
This PR fixes issue #54, where the Privacy and License links in the footer were not visible when dark mode was enabled. The update ensures consistent visibility in both light and dark themes.

Changes Made

Updated CSS styles for footer links to ensure proper contrast in dark mode.
Verified visibility for both License and Privacy pages in light mode and dark mode.
Maintained overall design consistency with the site’s theme.



<img width="1920" height="908" alt="Screenshot (136)" src="https://github.com/user-attachments/assets/5113cf20-1673-42d0-891e-4d55cda0201d" />
<img width="1920" height="911" alt="Screenshot (137)" src="https://github.com/user-attachments/assets/65a8ea17-749a-4f7c-b51f-f3c3bc020de8" />


