### PR TITLE
fix: replace hardcoded URL with environment variable

### DIFF
--- a/frontend/src/app/MessageContext.tsx
+++ b/frontend/src/app/MessageContext.tsx
@@ -37,7 +37,7 @@ export const MessageProvider = ({
   useEffect(() => {
     if (!currentUser) return
     const userId = currentUser.id
-    const socket = io("http://localhost:8080", {
+    const socket = io(process.env.NEXT_PUBLIC_API_URL ||"http://localhost:8080", {
       transports: ["websocket"],
       query: { userId },
     })


### PR DESCRIPTION
Fix #70 
Replaced Hardcoded API URLs with process.env with NEXT_PUBLIC_API_URL || "http://localhost:8080"
in MessageContext.tsx line 40