### PR TITLE
fix: restore Socket.IO fallback transport on login

### DIFF
--- a/frontend/src/app/MessageContext.tsx
+++ b/frontend/src/app/MessageContext.tsx
@@ -35,6 +35,8 @@ export interface MessageContextType { // CHANGED: Added MessageContextType
   error: string | null;
   setError: (error: string | null) => void;
   socket: Socket | null;
+  socketConnected: boolean;
+  socketError: string | null;
 }
 
 const MessageContext = createContext<MessageContextType | null>(null) // CHANGED: Use MessageContextType instead of any
@@ -65,26 +67,77 @@ export const MessageProvider = ({
   const [loadingMessages, setLoadingMessages] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [socket, setSocket] = useState<Socket | null>(null)
+  const [socketConnected, setSocketConnected] = useState<boolean>(false)
+  const [socketError, setSocketError] = useState<string | null>(null)
 
   // Connect to socket.io server with userId as query param
   useEffect(() => {
     if (!currentUser) return
     const userId = currentUser.id
-    const socket = io(process.env.NEXT_PUBLIC_API_URL ||"http://localhost:8080", {
-      transports: ["websocket"],
+
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL
+
+    if (!apiUrl && process.env.NODE_ENV === "production") {
+      const msg =
+        "NEXT_PUBLIC_API_URL is not set. Socket will attempt localhost:8080, which will fail in production."
+
+      console.error(msg)
+      setSocketError(msg)
+
+      toast.error(
+        "Configuration error: backend URL is not set. Contact your administrator.",
+        {
+          id: "socket-config-error",
+          duration: Infinity,
+        }
+      )
+
+      return
+    }
+
+    const resolvedUrl = apiUrl || "http://localhost:8080"
+
+    const socket = io(resolvedUrl, {
+      transports: ["polling", "websocket"],
       query: { userId },
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 2000,
     })
 
     socket.on("connect", () => {
       console.log("WebSocket connected successfully")
+      setSocketConnected(true)
+      setSocketError(null)
+
+      toast.success("Connected to chat server.", {
+        id: "socket-success",
+        duration: 2000,
+      })
     })
 
     socket.on("connect_error", (err) => {
-      console.error("WebSocket connection error:", err)
-      toast.error(`Chat server unreachable. Please check your connection or backend URL.`, {
-        id: "socket-error", // Persistent ID to prevent duplicate toasts
-        duration: 5000,
-      })
+      const detail = err.message || String(err)
+      const description =
+        (err as any).description ? ` (${(err as any).description})` : ""
+
+      console.error("WebSocket connection error:", detail + description, err)
+
+      setSocketConnected(false)
+      setSocketError(`Connection failed: ${detail}`)
+
+      toast.error(
+        `Chat server unreachable: ${detail}. Check NEXT_PUBLIC_API_URL or backend status.`,
+        {
+          id: "socket-error",
+          duration: 5000,
+        }
+      )
+    })
+
+    socket.on("disconnect", (reason) => {
+      console.warn("WebSocket disconnected:", reason)
+      setSocketConnected(false)
     })
 
     setSocket(socket)
@@ -306,6 +359,8 @@ export const MessageProvider = ({
         error,
         setError,
         socket,
+        socketConnected,
+        socketError,
       }}
     >
       {children}

--- a/frontend/src/app/fetcher.ts
+++ b/frontend/src/app/fetcher.ts
@@ -1,5 +1,13 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080"
 
+if (!process.env.NEXT_PUBLIC_API_URL && process.env.NODE_ENV === "production") {
+  console.error(
+    "[NPMChat] WARNING: NEXT_PUBLIC_API_URL is not set. " +
+      "All API calls will target http://localhost:8080, which will fail in production. " +
+      "Set NEXT_PUBLIC_API_URL to your backend URL."
+  )
+}
+
 const BASES = {
   auth:
     process.env.NEXT_PUBLIC_AUTH_API_BASE ||


### PR DESCRIPTION
## Related Issue

Closes #101

## Description

This PR fixes the Socket.IO connection failure occurring during login by replacing the websocket-only transport strategy with a polling-first handshake flow.

### What changed

- Replaced:
  ```ts
  transports: ["websocket"]
  ```
  with:
  ```ts
  transports: ["polling", "websocket"]
  ```

- Added socket connection state tracking:
  - `socketConnected`
  - `socketError`

- Added reconnect handling:
  - `reconnectionAttempts: 5`
  - `reconnectionDelay: 2000`

- Improved socket lifecycle handling:
  - `connect`
  - `connect_error`
  - `disconnect`

- Added production validation/warnings for missing `NEXT_PUBLIC_API_URL`

### Why this fixes the issue

The previous implementation forced a direct WebSocket connection during initialization. In some environments this caused the connection to terminate before the handshake completed.

Using Socket.IO’s default polling-first transport flow allows the client to establish a stable HTTP connection first and then upgrade to WebSocket safely.

## Validation

- Reproduced the issue locally
- Verified the original websocket failure
- Confirmed successful Socket.IO connection after the fix
- Verified reconnect behavior after refresh
- Confirmed no TypeScript/build issues

<details>
<summary>Before Fix</summary>

<br>

<img src="https://github.com/user-attachments/assets/19b5af19-a46a-4314-8ee3-4d0d6df087d5" width="850" />

</details>

<details>
<summary>After Fix</summary>

<br>

<img src="https://github.com/user-attachments/assets/0b6a810a-1cfd-4c8a-a877-d84be0c61cd2" width="850" />

</details>