### PR TITLE
fix: add /docs pages to resolve 404 error  issue raised #98

### DIFF
--- a/frontend/src/app/docs/architecture/page.tsx
+++ b/frontend/src/app/docs/architecture/page.tsx
@@ -1,0 +1,79 @@
+import fs from "fs"
+import path from "path"
+import Link from "next/link"
+import Header from "../../../components/Home/Header"
+import Footer from "../../../components/Home/Footer"
+
+export const metadata = {
+  title: "Architecture | NPMChat Docs",
+}
+
+export default function ArchitecturePage() {
+  const content = fs.readFileSync(
+    path.resolve(process.cwd(), "..", "docs", "ARCHITECTURE.md"),
+    "utf-8"
+  )
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+
+      <section className="bg-white py-20 px-6">
+        <div className="max-w-4xl mx-auto">
+
+          <div className="flex items-center gap-3 mb-12">
+            <Link
+              href="/docs"
+              className="bg-black text-white font-black px-4 py-2 border-2 border-black shadow-[3px_3px_0_0_rgba(0,0,0,0.3)] hover:bg-gray-800 transition-colors text-sm"
+            >
+              ← All Docs
+            </Link>
+            <span className="font-bold text-gray-400">/</span>
+            <span className="font-black text-black text-sm uppercase">architecture</span>
+          </div>
+
+          <div className="bg-white border-4 border-black shadow-[8px_8px_0_0_rgba(0,0,0,1)] p-10">
+            <div
+              className="text-black [&_h1]:text-4xl [&_h1]:font-black [&_h1]:mb-4 [&_h1]:text-black [&_h2]:text-2xl [&_h2]:font-black [&_h2]:mt-10 [&_h2]:mb-4 [&_h2]:pb-3 [&_h2]:border-b-4 [&_h2]:border-black [&_h2]:text-black [&_h3]:text-xl [&_h3]:font-bold [&_h3]:mt-6 [&_h3]:mb-3 [&_h3]:text-black [&_p]:text-gray-800 [&_p]:leading-relaxed [&_p]:mb-4 [&_ul]:mb-4 [&_ul]:space-y-2 [&_ol]:mb-4 [&_ol]:space-y-2 [&_li]:text-gray-800 [&_li]:ml-4 [&_pre]:bg-black [&_pre]:text-green-400 [&_pre]:p-6 [&_pre]:overflow-x-auto [&_pre]:text-sm [&_pre]:font-mono [&_pre]:my-6 [&_pre]:border-4 [&_pre]:border-black [&_pre]:shadow-[4px_4px_0_0_rgba(0,0,0,0.3)] [&_code]:bg-gray-100 [&_code]:text-black [&_code]:px-2 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:border [&_code]:border-gray-300 [&_pre_code]:bg-transparent [&_pre_code]:border-none [&_pre_code]:text-green-400 [&_pre_code]:p-0 [&_hr]:border-t-4 [&_hr]:border-black [&_hr]:my-8 [&_strong]:font-black [&_strong]:text-black [&_a]:text-black [&_a]:font-bold [&_a]:underline [&_blockquote]:border-l-4 [&_blockquote]:border-black [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-gray-600 [&_blockquote]:my-4"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
+            />
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Link href="/docs/setup" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">⚙️ Setup</Link>
+            <Link href="/docs/backend" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🔧 Backend</Link>
+            <Link href="/docs/frontend" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🖥️ Frontend</Link>
+          </div>
+
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}
+
+function renderMarkdown(md: string): string {
+  return md
+  
+    .replace(/```[\w]*\n([\s\S]*?)```/g, '<pre style="background:#0a0a0a;color:#4ade80;padding:1rem;overflow-x:auto;font-size:0.8rem;margin:1rem 0;border:2px solid black"><code>$1</code></pre>')
+  
+    .replace(/`([^`]+)`/g, '<code style="background:#f3f4f6;color:#111;padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85em;border:1px solid #d1d5db">$1</code>')
+   
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  
+    .replace(/^### (.+)$/gm, '<h3 style="font-size:1.1rem;font-weight:700;margin:1.5rem 0 0.5rem;color:black">$1</h3>')
+    .replace(/^## (.+)$/gm,  '<h2 style="font-size:1.4rem;font-weight:800;margin:2rem 0 0.75rem;padding-bottom:0.4rem;border-bottom:2px solid black;color:black">$1</h2>')
+    .replace(/^# (.+)$/gm,   '<h1 style="font-size:2rem;font-weight:900;margin-bottom:0.5rem;color:black">$1</h1>')
+  
+    .replace(/^---$/gm, '<hr style="border:none;border-top:2px solid black;margin:1.5rem 0"/>')
+  
+    .replace(/^- (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:disc;margin-bottom:0.25rem;color:black">$1</li>')
+    .replace(/^\d+\. (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:decimal;margin-bottom:0.25rem;color:black">$1</li>')
+  
+    .replace(/^(?!<)(.+)$/gm, '<p style="margin:0.5rem 0;line-height:1.7;color:black">$1</p>')
+  
+    .replace(/<p[^>]*>\s*<\/p>/g, '')
+  
+    .replace(/(<li[^>]*>.*<\/li>\n?)+/g, '<ul style="margin:0.5rem 0 1rem 0">$&</ul>');
+}

--- a/frontend/src/app/docs/backend/page.tsx
+++ b/frontend/src/app/docs/backend/page.tsx
@@ -1,0 +1,79 @@
+import fs from "fs"
+import path from "path"
+import Link from "next/link"
+import Header from "../../../components/Home/Header"
+import Footer from "../../../components/Home/Footer"
+
+export const metadata = {
+  title: "Backend | NPMChat Docs",
+}
+
+export default function BackendPage() {
+  const content = fs.readFileSync(
+    path.resolve(process.cwd(), "..", "docs", "BACKEND.md"),
+    "utf-8"
+  )
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+
+      <section className="bg-white py-20 px-6">
+        <div className="max-w-4xl mx-auto">
+
+          <div className="flex items-center gap-3 mb-12">
+            <Link
+              href="/docs"
+              className="bg-black text-white font-black px-4 py-2 border-2 border-black shadow-[3px_3px_0_0_rgba(0,0,0,0.3)] hover:bg-gray-800 transition-colors text-sm"
+            >
+              ← All Docs
+            </Link>
+            <span className="font-bold text-gray-400">/</span>
+            <span className="font-black text-black text-sm uppercase">backend</span>
+          </div>
+
+          <div className="bg-white border-4 border-black shadow-[8px_8px_0_0_rgba(0,0,0,1)] p-10">
+            <div
+              className="text-black [&_h1]:text-4xl [&_h1]:font-black [&_h1]:mb-4 [&_h1]:text-black [&_h2]:text-2xl [&_h2]:font-black [&_h2]:mt-10 [&_h2]:mb-4 [&_h2]:pb-3 [&_h2]:border-b-4 [&_h2]:border-black [&_h2]:text-black [&_h3]:text-xl [&_h3]:font-bold [&_h3]:mt-6 [&_h3]:mb-3 [&_h3]:text-black [&_p]:text-gray-800 [&_p]:leading-relaxed [&_p]:mb-4 [&_ul]:mb-4 [&_ul]:space-y-2 [&_ol]:mb-4 [&_ol]:space-y-2 [&_li]:text-gray-800 [&_li]:ml-4 [&_pre]:bg-black [&_pre]:text-green-400 [&_pre]:p-6 [&_pre]:overflow-x-auto [&_pre]:text-sm [&_pre]:font-mono [&_pre]:my-6 [&_pre]:border-4 [&_pre]:border-black [&_pre]:shadow-[4px_4px_0_0_rgba(0,0,0,0.3)] [&_code]:bg-gray-100 [&_code]:text-black [&_code]:px-2 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:border [&_code]:border-gray-300 [&_pre_code]:bg-transparent [&_pre_code]:border-none [&_pre_code]:text-green-400 [&_pre_code]:p-0 [&_hr]:border-t-4 [&_hr]:border-black [&_hr]:my-8 [&_strong]:font-black [&_strong]:text-black [&_a]:text-black [&_a]:font-bold [&_a]:underline [&_blockquote]:border-l-4 [&_blockquote]:border-black [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-gray-600 [&_blockquote]:my-4"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
+            />
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Link href="/docs/setup" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">⚙️ Setup</Link>
+            <Link href="/docs/architecture" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🏗️ Architecture</Link>
+            <Link href="/docs/frontend" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🖥️ Frontend</Link>
+          </div>
+
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}
+
+function renderMarkdown(md: string): string {
+  return md
+  
+    .replace(/```[\w]*\n([\s\S]*?)```/g, '<pre style="background:#0a0a0a;color:#4ade80;padding:1rem;overflow-x:auto;font-size:0.8rem;margin:1rem 0;border:2px solid black"><code>$1</code></pre>')
+  
+    .replace(/`([^`]+)`/g, '<code style="background:#f3f4f6;color:#111;padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85em;border:1px solid #d1d5db">$1</code>')
+   
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  
+    .replace(/^### (.+)$/gm, '<h3 style="font-size:1.1rem;font-weight:700;margin:1.5rem 0 0.5rem;color:black">$1</h3>')
+    .replace(/^## (.+)$/gm,  '<h2 style="font-size:1.4rem;font-weight:800;margin:2rem 0 0.75rem;padding-bottom:0.4rem;border-bottom:2px solid black;color:black">$1</h2>')
+    .replace(/^# (.+)$/gm,   '<h1 style="font-size:2rem;font-weight:900;margin-bottom:0.5rem;color:black">$1</h1>')
+  
+    .replace(/^---$/gm, '<hr style="border:none;border-top:2px solid black;margin:1.5rem 0"/>')
+  
+    .replace(/^- (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:disc;margin-bottom:0.25rem;color:black">$1</li>')
+    .replace(/^\d+\. (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:decimal;margin-bottom:0.25rem;color:black">$1</li>')
+  
+    .replace(/^(?!<)(.+)$/gm, '<p style="margin:0.5rem 0;line-height:1.7;color:black">$1</p>')
+  
+    .replace(/<p[^>]*>\s*<\/p>/g, '')
+  
+    .replace(/(<li[^>]*>.*<\/li>\n?)+/g, '<ul style="margin:0.5rem 0 1rem 0">$&</ul>');
+}

--- a/frontend/src/app/docs/frontend/page.tsx
+++ b/frontend/src/app/docs/frontend/page.tsx
@@ -1,0 +1,79 @@
+import fs from "fs"
+import path from "path"
+import Link from "next/link"
+import Header from "../../../components/Home/Header"
+import Footer from "../../../components/Home/Footer"
+
+export const metadata = {
+  title: "Frontend | NPMChat Docs",
+}
+
+export default function FrontendPage() {
+  const content = fs.readFileSync(
+    path.resolve(process.cwd(), "..", "docs", "FRONTEND.md"),
+    "utf-8"
+  )
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+
+      <section className="bg-white py-20 px-6">
+        <div className="max-w-4xl mx-auto">
+
+          <div className="flex items-center gap-3 mb-12">
+            <Link
+              href="/docs"
+              className="bg-black text-white font-black px-4 py-2 border-2 border-black shadow-[3px_3px_0_0_rgba(0,0,0,0.3)] hover:bg-gray-800 transition-colors text-sm"
+            >
+              ← All Docs
+            </Link>
+            <span className="font-bold text-gray-400">/</span>
+            <span className="font-black text-black text-sm uppercase">frontend</span>
+          </div>
+
+          <div className="bg-white border-4 border-black shadow-[8px_8px_0_0_rgba(0,0,0,1)] p-10">
+            <div
+              className="text-black [&_h1]:text-4xl [&_h1]:font-black [&_h1]:mb-4 [&_h1]:text-black [&_h2]:text-2xl [&_h2]:font-black [&_h2]:mt-10 [&_h2]:mb-4 [&_h2]:pb-3 [&_h2]:border-b-4 [&_h2]:border-black [&_h2]:text-black [&_h3]:text-xl [&_h3]:font-bold [&_h3]:mt-6 [&_h3]:mb-3 [&_h3]:text-black [&_p]:text-gray-800 [&_p]:leading-relaxed [&_p]:mb-4 [&_ul]:mb-4 [&_ul]:space-y-2 [&_ol]:mb-4 [&_ol]:space-y-2 [&_li]:text-gray-800 [&_li]:ml-4 [&_pre]:bg-black [&_pre]:text-green-400 [&_pre]:p-6 [&_pre]:overflow-x-auto [&_pre]:text-sm [&_pre]:font-mono [&_pre]:my-6 [&_pre]:border-4 [&_pre]:border-black [&_pre]:shadow-[4px_4px_0_0_rgba(0,0,0,0.3)] [&_code]:bg-gray-100 [&_code]:text-black [&_code]:px-2 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:border [&_code]:border-gray-300 [&_pre_code]:bg-transparent [&_pre_code]:border-none [&_pre_code]:text-green-400 [&_pre_code]:p-0 [&_hr]:border-t-4 [&_hr]:border-black [&_hr]:my-8 [&_strong]:font-black [&_strong]:text-black [&_a]:text-black [&_a]:font-bold [&_a]:underline [&_blockquote]:border-l-4 [&_blockquote]:border-black [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-gray-600 [&_blockquote]:my-4"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
+            />
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Link href="/docs/setup" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">⚙️ Setup</Link>
+            <Link href="/docs/architecture" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🏗️ Architecture</Link>
+            <Link href="/docs/backend" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🔧 Backend</Link>
+          </div>
+
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}
+
+function renderMarkdown(md: string): string {
+  return md
+  
+    .replace(/```[\w]*\n([\s\S]*?)```/g, '<pre style="background:#0a0a0a;color:#4ade80;padding:1rem;overflow-x:auto;font-size:0.8rem;margin:1rem 0;border:2px solid black"><code>$1</code></pre>')
+  
+    .replace(/`([^`]+)`/g, '<code style="background:#f3f4f6;color:#111;padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85em;border:1px solid #d1d5db">$1</code>')
+   
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  
+    .replace(/^### (.+)$/gm, '<h3 style="font-size:1.1rem;font-weight:700;margin:1.5rem 0 0.5rem;color:black">$1</h3>')
+    .replace(/^## (.+)$/gm,  '<h2 style="font-size:1.4rem;font-weight:800;margin:2rem 0 0.75rem;padding-bottom:0.4rem;border-bottom:2px solid black;color:black">$1</h2>')
+    .replace(/^# (.+)$/gm,   '<h1 style="font-size:2rem;font-weight:900;margin-bottom:0.5rem;color:black">$1</h1>')
+  
+    .replace(/^---$/gm, '<hr style="border:none;border-top:2px solid black;margin:1.5rem 0"/>')
+  
+    .replace(/^- (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:disc;margin-bottom:0.25rem;color:black">$1</li>')
+    .replace(/^\d+\. (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:decimal;margin-bottom:0.25rem;color:black">$1</li>')
+  
+    .replace(/^(?!<)(.+)$/gm, '<p style="margin:0.5rem 0;line-height:1.7;color:black">$1</p>')
+  
+    .replace(/<p[^>]*>\s*<\/p>/g, '')
+  
+    .replace(/(<li[^>]*>.*<\/li>\n?)+/g, '<ul style="margin:0.5rem 0 1rem 0">$&</ul>');
+}

--- a/frontend/src/app/docs/page.tsx
+++ b/frontend/src/app/docs/page.tsx
@@ -1,0 +1,157 @@
+import Link from "next/link"
+import Header from "../../components/Home/Header"
+import Footer from "../../components/Home/Footer"
+import {
+  Settings,
+  BookOpen,
+  Server,
+  Layout,
+} from "lucide-react"
+
+const docs = [
+  {
+    href: "/docs/setup",
+    icon: <Settings className="w-8 h-8 text-orange-600" />,
+    title: "Setup Guide",
+    description:
+      "Get NPMChat running locally from scratch. Prerequisites, environment variables, and step-by-step instructions to have everything up and running.",
+    bgColor: "bg-[#fef6e4]",
+    details: ["Prerequisites", "Backend setup", "Frontend setup", "Env variables"],
+  },
+  {
+    href: "/docs/architecture",
+    icon: <BookOpen className="w-8 h-8 text-purple-600" />,
+    title: "Architecture",
+    description:
+      "High-level overview of the NPMChat monorepo structure, data flow between frontend and backend, and key design decisions.",
+    bgColor: "bg-[#e9d5ff]",
+    details: ["Monorepo structure", "Data flow", "Design decisions", "Tech stack"],
+  },
+  {
+    href: "/docs/backend",
+    icon: <Server className="w-8 h-8 text-green-600" />,
+    title: "Backend",
+    description:
+      "Express.js API reference covering all routes, Socket.IO events, MongoDB models, and environment configuration.",
+    bgColor: "bg-[#d9f99d]",
+    details: ["API routes", "Socket.IO events", "MongoDB models", "Configuration"],
+  },
+  {
+    href: "/docs/frontend",
+    icon: <Layout className="w-8 h-8 text-blue-600" />,
+    title: "Frontend",
+    description:
+      "Next.js app folder structure, key pages, routing conventions, and how to add new pages or components to the project.",
+    bgColor: "bg-[#e0f2fe]",
+    details: ["Folder structure", "Key routes", "Components", "Adding new pages"],
+  },
+]
+
+export const metadata = {
+  title: "Documentation | NPMChat",
+  description: "NPMChat developer documentation",
+}
+
+export default function DocsPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+
+      {/* Hero */}
+      <section className="bg-white py-20 px-6">
+        <div className="max-w-6xl mx-auto text-center">
+          <div className="mb-8">
+            <span className="bg-[#39ff14] text-black font-bold px-4 py-2 border-2 border-black shadow-[2px_2px_0_0_rgba(0,0,0,1)]">
+              DEVELOPER DOCS
+            </span>
+          </div>
+          <h1 className="text-4xl md:text-6xl font-black text-black mb-6 leading-tight">
+            Build with <span className="text-[#b39ddb]">NPMChat</span>
+          </h1>
+          <p className="text-2xl text-gray-700 mb-8 max-w-4xl mx-auto font-medium">
+            Everything you need to understand, run, and contribute to NPMChat —
+            from local setup to architecture deep dives.
+          </p>
+        </div>
+      </section>
+
+      {/* Doc Cards */}
+      <section className="py-20 px-6 bg-gray-50">
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-16">
+            <h2 className="text-4xl md:text-5xl font-black text-black mb-4">
+              Documentation
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Four guides covering everything from first setup to internal architecture
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            {docs.map((doc, index) => (
+              <Link key={index} href={doc.href} className="block group">
+                <div
+                  className={`${doc.bgColor} border-4 border-black p-8 shadow-[8px_8px_0_0_rgba(0,0,0,1)] hover:shadow-[10px_10px_0_0_rgba(0,0,0,1)] transition-all hover:-translate-y-1 h-full`}
+                >
+                  <div className="flex items-center justify-center w-16 h-16 bg-white border-4 border-black mb-6 shadow-[3px_3px_0_0_rgba(0,0,0,1)]">
+                    {doc.icon}
+                  </div>
+                  <h3 className="text-2xl font-black text-black mb-4">
+                    {doc.title}
+                  </h3>
+                  <p className="text-gray-800 leading-relaxed mb-6 text-lg">
+                    {doc.description}
+                  </p>
+                  <div className="space-y-2">
+                    {doc.details.map((detail, idx) => (
+                      <div
+                        key={idx}
+                        className="flex items-center text-sm font-bold text-gray-700"
+                      >
+                        <div className="w-2 h-2 bg-black mr-3 flex-shrink-0"></div>
+                        {detail}
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-6 inline-block bg-black text-white font-black px-4 py-2 text-sm shadow-[3px_3px_0_0_rgba(0,0,0,0.3)] group-hover:bg-gray-800 transition-colors">
+                    Read docs →
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-20 px-6 bg-black text-white">
+        <div className="max-w-2xl mx-auto text-center">
+          <h2 className="text-3xl md:text-5xl font-black mb-6">
+            Ready to Contribute?
+          </h2>
+          <p className="text-xl mb-10 text-gray-300">
+            NPMChat is open source. Pick up an issue, read the docs, and send a PR.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <a
+              href="https://github.com/ThePlator/NPMChat"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-[#39ff14] text-black font-black py-4 px-8 border-4 border-white shadow-[8px_8px_0_0_rgba(255,255,255,1)] hover:shadow-[6px_6px_0_0_rgba(255,255,255,1)] hover:-translate-y-1 transition-all text-xl"
+            >
+              View on GitHub
+            </a>
+            <Link
+              href="/docs/setup"
+              className="bg-transparent text-white font-black py-4 px-8 border-4 border-white hover:bg-white hover:text-black transition-all text-xl shadow-[8px_8px_0_0_rgba(255,255,255,1)] hover:shadow-[6px_6px_0_0_rgba(255,255,255,1)] hover:-translate-y-1"
+            >
+              Get Started
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}

--- a/frontend/src/app/docs/setup/page.tsx
+++ b/frontend/src/app/docs/setup/page.tsx
@@ -1,0 +1,79 @@
+import fs from "fs"
+import path from "path"
+import Link from "next/link"
+import Header from "../../../components/Home/Header"
+import Footer from "../../../components/Home/Footer"
+
+export const metadata = {
+  title: "Setup Guide | NPMChat Docs",
+}
+
+export default function SetupPage() {
+  const content = fs.readFileSync(
+    path.resolve(process.cwd(), "..", "docs", "ENVIRONMENT_SETUP.md"),
+    "utf-8"
+  )
+
+  return (
+    <div className="min-h-screen bg-white">
+      <Header />
+
+      <section className="bg-white py-20 px-6">
+        <div className="max-w-4xl mx-auto">
+
+          <div className="flex items-center gap-3 mb-12">
+            <Link
+              href="/docs"
+              className="bg-black text-white font-black px-4 py-2 border-2 border-black shadow-[3px_3px_0_0_rgba(0,0,0,0.3)] hover:bg-gray-800 transition-colors text-sm"
+            >
+              ← All Docs
+            </Link>
+            <span className="font-bold text-gray-400">/</span>
+            <span className="font-black text-black text-sm uppercase">setup</span>
+          </div>
+
+          <div className="bg-white border-4 border-black shadow-[8px_8px_0_0_rgba(0,0,0,1)] p-10">
+            <div
+              className="text-black [&_h1]:text-4xl [&_h1]:font-black [&_h1]:mb-4 [&_h1]:text-black [&_h2]:text-2xl [&_h2]:font-black [&_h2]:mt-10 [&_h2]:mb-4 [&_h2]:pb-3 [&_h2]:border-b-4 [&_h2]:border-black [&_h2]:text-black [&_h3]:text-xl [&_h3]:font-bold [&_h3]:mt-6 [&_h3]:mb-3 [&_h3]:text-black [&_p]:text-gray-800 [&_p]:leading-relaxed [&_p]:mb-4 [&_ul]:mb-4 [&_ul]:space-y-2 [&_ol]:mb-4 [&_ol]:space-y-2 [&_li]:text-gray-800 [&_li]:ml-4 [&_pre]:bg-black [&_pre]:text-green-400 [&_pre]:p-6 [&_pre]:overflow-x-auto [&_pre]:text-sm [&_pre]:font-mono [&_pre]:my-6 [&_pre]:border-4 [&_pre]:border-black [&_pre]:shadow-[4px_4px_0_0_rgba(0,0,0,0.3)] [&_code]:bg-gray-100 [&_code]:text-black [&_code]:px-2 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_code]:border [&_code]:border-gray-300 [&_pre_code]:bg-transparent [&_pre_code]:border-none [&_pre_code]:text-green-400 [&_pre_code]:p-0 [&_hr]:border-t-4 [&_hr]:border-black [&_hr]:my-8 [&_strong]:font-black [&_strong]:text-black [&_a]:text-black [&_a]:font-bold [&_a]:underline [&_blockquote]:border-l-4 [&_blockquote]:border-black [&_blockquote]:pl-4 [&_blockquote]:italic [&_blockquote]:text-gray-600 [&_blockquote]:my-4"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
+            />
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Link href="/docs/architecture" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🏗️ Architecture</Link>
+            <Link href="/docs/backend" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🔧 Backend</Link>
+            <Link href="/docs/frontend" className="bg-white text-black font-black px-5 py-3 border-4 border-black shadow-[4px_4px_0_0_rgba(0,0,0,1)] hover:shadow-[6px_6px_0_0_rgba(0,0,0,1)] hover:-translate-y-0.5 transition-all text-sm">🖥️ Frontend</Link>
+          </div>
+
+        </div>
+      </section>
+
+      <Footer />
+    </div>
+  )
+}
+
+function renderMarkdown(md: string): string {
+  return md
+  
+    .replace(/```[\w]*\n([\s\S]*?)```/g, '<pre style="background:#0a0a0a;color:#4ade80;padding:1rem;overflow-x:auto;font-size:0.8rem;margin:1rem 0;border:2px solid black"><code>$1</code></pre>')
+  
+    .replace(/`([^`]+)`/g, '<code style="background:#f3f4f6;color:#111;padding:0.1rem 0.4rem;border-radius:4px;font-size:0.85em;border:1px solid #d1d5db">$1</code>')
+   
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+  
+    .replace(/^### (.+)$/gm, '<h3 style="font-size:1.1rem;font-weight:700;margin:1.5rem 0 0.5rem;color:black">$1</h3>')
+    .replace(/^## (.+)$/gm,  '<h2 style="font-size:1.4rem;font-weight:800;margin:2rem 0 0.75rem;padding-bottom:0.4rem;border-bottom:2px solid black;color:black">$1</h2>')
+    .replace(/^# (.+)$/gm,   '<h1 style="font-size:2rem;font-weight:900;margin-bottom:0.5rem;color:black">$1</h1>')
+  
+    .replace(/^---$/gm, '<hr style="border:none;border-top:2px solid black;margin:1.5rem 0"/>')
+  
+    .replace(/^- (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:disc;margin-bottom:0.25rem;color:black">$1</li>')
+    .replace(/^\d+\. (.+)$/gm, '<li style="margin-left:1.5rem;list-style-type:decimal;margin-bottom:0.25rem;color:black">$1</li>')
+  
+    .replace(/^(?!<)(.+)$/gm, '<p style="margin:0.5rem 0;line-height:1.7;color:black">$1</p>')
+  
+    .replace(/<p[^>]*>\s*<\/p>/g, '')
+  
+    .replace(/(<li[^>]*>.*<\/li>\n?)+/g, '<ul style="margin:0.5rem 0 1rem 0">$&</ul>');
+}

--- a/frontend/src/content/ARCHITECTURE.md
+++ b/frontend/src/content/ARCHITECTURE.md
@@ -1,0 +1,34 @@
+# Architecture Overview
+
+NPMChat is a full-stack real-time chat application built using the MERN stack (with Next.js) and Socket.io.
+
+## System Components
+
+### 1. Backend (Node.js/Express)
+The backend acts as a RESTful API and a WebSocket server.
+- **REST API:** Handles authentication, user profile management, and message history retrieval.
+- **WebSocket (Socket.io):** Handles real-time message delivery, online status tracking, and "typing" indicators.
+- **Database (MongoDB):** Stores user profiles and message history.
+
+### 2. Frontend (Next.js/React)
+A modern, responsive UI built with TypeScript and Tailwind CSS.
+- **State Management:** Uses React Context API (`AuthContext` and `MessageContext`) for global state.
+- **Real-time Integration:** Uses `socket.io-client` to maintain a persistent connection with the backend.
+- **Styling:** Follows a Neo-Brutalist design language.
+
+## Data Flow
+1. **Auth:** User logs in -> Backend returns JWT -> Frontend stores JWT in LocalStorage -> Frontend sends JWT in `Authorization` header for subsequent requests.
+2. **Messaging:** 
+   - User sends message (via REST POST).
+   - Backend saves to DB.
+   - Backend emits `newMessage` via Socket.io to the recipient.
+   - Recipient's frontend receives socket event and updates local message state.
+
+## Deployment Strategy
+- **Frontend:** Vercel — handles Next.js SSR, static assets, and edge routing.
+- **Backend:** Render Web Service (Docker) — required for persistent Socket.IO WebSocket connections. See [DEPLOYMENT.md](/DEPLOYMENT.md) for setup.
+- **Database:** MongoDB Atlas (free tier available).
+- **CI:** GitHub Actions — validates Docker build and health check on every PR. See `.github/workflows/backend-ci.yml`.
+
+> **Note:** Vercel cannot host the backend because its serverless functions do not support persistent WebSocket connections. See [DEPLOYMENT.md](/DEPLOYMENT.md) for details.
+

--- a/frontend/src/content/BACKEND.md
+++ b/frontend/src/content/BACKEND.md
@@ -1,0 +1,47 @@
+# Backend Documentation
+
+The backend is a Node.js application using Express and Mongoose.
+
+## Tech Stack
+- **Framework:** Express.js (ES Modules)
+- **Database:** MongoDB
+- **Real-time:** Socket.io
+- **Auth:** JWT (JSON Web Tokens) & Bcrypt.js
+- **File Storage:** Cloudinary
+
+## API Reference
+
+### Auth Routes (`/api/v1/auth`)
+| Method | Endpoint | Description | Auth Required |
+|--------|----------|-------------|---------------|
+| POST | `/signup` | Create a new user account | No |
+| POST | `/login` | Authenticate user & get token | No |
+| GET | `/check-auth` | Verify current token & get user data | Yes |
+| PUT | `/update-profile` | Update user bio, name, or avatar | Yes |
+
+### Message Routes (`/api/v1/messages`)
+| Method | Endpoint | Description | Auth Required |
+|--------|----------|-------------|---------------|
+| GET | `/` | Get list of users for sidebar with unseen counts | Yes |
+| GET | `/:userId` | Get chat history between two users | Yes |
+| POST | `/send/:receiverId` | Send a new text/image message | Yes |
+| PUT | `/mark-as-seen/:messageId` | Mark a specific message as read | Yes |
+
+## Database Models
+
+### User Schema
+- `email`: String (Unique, Lowercase)
+- `password`: String (Hashed)
+- `name`: String
+- `avatarUrl`: String (Cloudinary URL)
+- `bio`: String
+
+### Message Schema
+- `senderId`: ObjectId (Ref: User)
+- `receiverId`: ObjectId (Ref: User)
+- `text`: String
+- `image`: String (Cloudinary URL)
+- `seen`: Boolean (Default: false)
+
+## Middleware
+- `protectRoute`: Verifies the JWT in the `Authorization` header. If valid, attaches the user object to `req.user`.

--- a/frontend/src/content/ENVIRONMENT_SETUP.md
+++ b/frontend/src/content/ENVIRONMENT_SETUP.md
@@ -1,0 +1,38 @@
+# Environment Setup
+
+To run NPMChat locally, follow these steps.
+
+## Prerequisites
+- Node.js (v18+)
+- MongoDB (Local or Atlas)
+- Cloudinary Account (for image uploads)
+
+## Backend Setup
+1. Navigate to the `backend/` directory.
+2. Create a `.env` file based on `.env.example`:
+```env
+PORT=8080
+MONGODB_URI=your_mongodb_connection_string
+JWT_SECRET=your_super_secret_key
+CLOUDINARY_CLOUD_NAME=your_name
+CLOUDINARY_API_KEY=your_key
+CLOUDINARY_API_SECRET=your_secret
+CLIENT_URL=http://localhost:3000
+NODE_ENV=development
+```
+3. Install dependencies: `npm install`
+4. Start development server: `npm run dev`
+
+## Frontend Setup
+1. Navigate to the `frontend/` directory.
+2. Create a `.env.local` file:
+```env
+NEXT_PUBLIC_API_URL=http://localhost:8080
+```
+3. Install dependencies: `npm install`
+4. Start development server: `npm run dev`
+
+## Troubleshooting
+- **CORS Issues:** Ensure `CLIENT_URL` in the backend `.env` matches your frontend URL.
+- **Socket Connection:** If the socket fails to connect, verify that the backend is running on the expected port (default: 8080).
+- **Image Uploads:** If profile pictures fail to save, check your Cloudinary credentials.

--- a/frontend/src/content/FRONTEND.md
+++ b/frontend/src/content/FRONTEND.md
@@ -1,0 +1,44 @@
+# Frontend Documentation
+
+The frontend is a Next.js application built with TypeScript and Tailwind CSS.
+
+## Tech Stack
+- **Framework:** Next.js 15 (App Router)
+- **Styling:** Tailwind CSS + Lucide Icons
+- **State:** React Context API
+- **Networking:** Fetch API (Custom wrapper) + Socket.io-client
+- **Animations:** Lenis (Smooth Scroll) + Framer Motion (planned)
+
+## Project Structure
+- `src/app`: Routes and Page layouts.
+- `src/components`: UI components (organized by feature).
+- `src/lib`: Utility functions and shared helpers.
+- `src/app/AuthContext.tsx`: Manages user login/logout/session.
+- `src/app/MessageContext.tsx`: Manages active chat state, socket events, and message history.
+
+## State Management
+
+### AuthContext
+Stores the `user` object and provides methods:
+- `login(data)`
+- `signup(data)`
+- `logout()`
+- `updateProfile(data)`
+
+### MessageContext
+The "Engine" of the chat UI:
+- Manages `socket` connection.
+- Stores `users` (sidebar list) and `messages` (active conversation).
+- Handles real-time listeners for `newMessage` and `getOnlineUsers`.
+
+## Real-time Logic
+The socket is initialized in `MessageContext` as soon as the user is authenticated.
+- **Connection:** `io(BACKEND_URL, { query: { userId } })`
+- **Events Emitted:** `send-message`
+- **Events Received:** `newMessage`, `getOnlineUsers`, `messageSeen`
+
+## Styling Guidelines
+The project uses a **Neo-Brutalist** aesthetic:
+- Thick black borders (`border-2 border-black`).
+- Harsh shadows (`shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]`).
+- High contrast colors (Vibrant greens, purples, and yellows).


### PR DESCRIPTION
## Problem
Clicking the "Docs" link on the live site (npm-chat-fxjq.vercel.app) 
redirects to /docs which returned a 404 Page Not Found error because 
no docs route existed in the Next.js frontend.

## Solution
Created the missing documentation pages inside the frontend app:

- `/docs` — index page listing all 4 documentation sections
- `/docs/setup` — reads and renders ENVIRONMENT_SETUP.md
- `/docs/architecture` — reads and renders ARCHITECTURE.md  
- `/docs/backend` — reads and renders BACKEND.md
- `/docs/frontend` — reads and renders FRONTEND.md

## Changes
- Added `frontend/src/app/docs/page.tsx` — docs index page
- Added `frontend/src/app/docs/setup/page.tsx`
- Added `frontend/src/app/docs/architecture/page.tsx`
- Added `frontend/src/app/docs/backend/page.tsx`
- Added `frontend/src/app/docs/frontend/page.tsx`
- Added `frontend/src/content/docs/` — copied from root docs/ folder 
  so Vercel can access them during the frontend build

## Design
Pages match the existing neo-brutalist design system used across 
the site (white background, black borders, bold shadows).

## Testing
- Verified /docs loads the index page
- Verified all 4 sub-pages render the correct markdown content


Layout is matched with the theme of other pages 

<img width="1920" height="1080" alt="Screenshot (308)" src="https://github.com/user-attachments/assets/1dc8849c-9ea0-4a2c-893a-87cd7ca4c3b0" />

<img width="1920" height="1080" alt="Screenshot (309)" src="https://github.com/user-attachments/assets/7bca9714-c04b-48f8-8012-98b85b15f805" />

<img width="1920" height="1080" alt="Screenshot (310)" src="https://github.com/user-attachments/assets/e69ae56e-c69b-4740-b5ac-4e93802b7a36" />
