### PR TITLE
fix: remove insecure query.userId fallback from Socket.IO auth middleware

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -115,25 +115,22 @@ io.use((socket, next) => {
 })
 
 io.use(async (socket, next) => {
-  const token = socket.handshake.auth.token
-  if (token) {
-    try {
-      const decoded = jwt.verify(token, process.env.JWT_SECRET)
-      socket.userId = decoded.id
-      return next()
-    } catch (err) {
-      console.error("Socket auth token invalid:", err.message)
-    }
+  const token = socket.handshake.auth?.token
+  if (!token) {
+    return next(new Error("Authentication error: No token provided"))
   }
 
-  // Fallback to query.userId for compatibility
-  const userId = socket.handshake.query.userId
-  if (userId) {
-    socket.userId = userId
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET)
+    socket.userId = decoded.id
     return next()
+  } catch (err) {
+    if (err.name === "TokenExpiredError") {
+      return next(new Error("Authentication error: Token expired"))
+    }
+    console.error("Socket auth token invalid:", err.message)
+    return next(new Error("Authentication error: Invalid token"))
   }
-
-  next(new Error("Authentication error: No token or userId provided"))
 })
 
 io.on("connection", async (socket) => {


### PR DESCRIPTION
## Description

Fixes #128

The Socket.IO authentication middleware had a critical bypass vulnerability. After attempting JWT verification, it fell back to trusting a bare `userId` from the query string (`socket.handshake.query.userId`). This meant any client could supply an arbitrary `userId` and:

1. Hijack undelivered messages intended for that user (via the delivery sweep on connect)
2. Intercept live messages by being automatically joined to the victim's socket room
3. Impersonate the user in real-time chat

Since PR #122 recently updated the frontend to send the JWT in the `auth` object (`socket.handshake.auth.token`), this fallback is no longer needed.

## Changes Made

- **`backend/server.js`**: Removed the `socket.handshake.query.userId` fallback block.
- Made JWT verification mandatory for all WebSocket connections.
- Added safe optional chaining (`socket.handshake.auth?.token`) and robust error handling to return specific rejection reasons (e.g. `TokenExpiredError`) to clients connecting with invalid tokens.

## How it works

Now, any client connecting without a valid JWT token is rejected outright (`next(new Error("Authentication error: No token provided"))`), closing the bypass vulnerability.

## GSSoC 2026

This PR is submitted as part of GSSoC 2026. Closes #128.
