### PR TITLE
feat: implement theme customizer and accessibility settings drawer

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2082,6 +2082,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/frontend/src/app/SettingsContext.tsx
+++ b/frontend/src/app/SettingsContext.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import React, { createContext, useContext, useEffect, useState } from "react"
+
+type TextScale = "small" | "medium" | "large" | "xlarge"
+
+interface SettingsContextType {
+  accentColor: string
+  setAccentColor: (color: string) => void
+  textScale: TextScale
+  setTextScale: (scale: TextScale) => void
+  highContrast: boolean
+  setHighContrast: (enabled: boolean) => void
+  reduceMotion: boolean
+  setReduceMotion: (enabled: boolean) => void
+}
+
+const SettingsContext = createContext<SettingsContextType | undefined>(undefined)
+
+export function SettingsProvider({ children }: { children: React.ReactNode }) {
+  const [accentColor, setAccentColor] = useState<string>("#39ff14") // Default neon green
+  const [textScale, setTextScale] = useState<TextScale>("medium")
+  const [highContrast, setHighContrast] = useState<boolean>(false)
+  const [reduceMotion, setReduceMotion] = useState<boolean>(false)
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    const savedAccentColor = localStorage.getItem("npmchat-accent-color")
+    const savedTextScale = localStorage.getItem("npmchat-text-scale") as TextScale
+    const savedHighContrast = localStorage.getItem("npmchat-high-contrast")
+    const savedReduceMotion = localStorage.getItem("npmchat-reduce-motion")
+
+    if (savedAccentColor) setAccentColor(savedAccentColor)
+    if (savedTextScale) setTextScale(savedTextScale)
+    if (savedHighContrast) setHighContrast(savedHighContrast === "true")
+    if (savedReduceMotion) setReduceMotion(savedReduceMotion === "true")
+  }, [])
+
+  // Update variables and localStorage on change
+  useEffect(() => {
+    localStorage.setItem("npmchat-accent-color", accentColor)
+    document.documentElement.style.setProperty("--color-neon-green", accentColor)
+    document.documentElement.style.setProperty("--neon-green", accentColor)
+  }, [accentColor])
+
+  useEffect(() => {
+    localStorage.setItem("npmchat-text-scale", textScale)
+    document.documentElement.setAttribute("data-text-scale", textScale)
+  }, [textScale])
+
+  useEffect(() => {
+    localStorage.setItem("npmchat-high-contrast", String(highContrast))
+    document.documentElement.setAttribute("data-high-contrast", String(highContrast))
+  }, [highContrast])
+
+  useEffect(() => {
+    localStorage.setItem("npmchat-reduce-motion", String(reduceMotion))
+    document.documentElement.setAttribute("data-reduce-motion", String(reduceMotion))
+  }, [reduceMotion])
+
+  return (
+    <SettingsContext.Provider
+      value={{
+        accentColor,
+        setAccentColor,
+        textScale,
+        setTextScale,
+        highContrast,
+        setHighContrast,
+        reduceMotion,
+        setReduceMotion,
+      }}
+    >
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export function useSettings() {
+  const context = useContext(SettingsContext)
+  if (context === undefined) {
+    throw new Error("useSettings must be used within a SettingsProvider")
+  }
+  return context
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -211,3 +211,206 @@ button:hover,
     @apply bg-background text-foreground;
   }
 }
+
+/* -------------------------------------------------------------
+   DEVELOPER THEMES
+   ------------------------------------------------------------- */
+
+/* Dracula Theme */
+.dracula {
+  --background: oklch(0.245 0.04 290); /* #282a36 */
+  --foreground: oklch(0.965 0 0); /* #f8f8f2 */
+  --card: oklch(0.26 0.04 290); /* #282a36 slightly lighter */
+  --card-foreground: oklch(0.965 0 0);
+  --popover: oklch(0.26 0.04 290);
+  --popover-foreground: oklch(0.965 0 0);
+  --primary: oklch(0.68 0.16 320); /* #bd93f9 */
+  --primary-foreground: oklch(0.245 0.04 290);
+  --secondary: oklch(0.3 0.05 290); /* #44475a */
+  --secondary-foreground: oklch(0.965 0 0);
+  --muted: oklch(0.3 0.05 290);
+  --muted-foreground: oklch(0.65 0.05 290); /* #6272a4 */
+  --accent: oklch(0.3 0.05 290);
+  --accent-foreground: oklch(0.965 0 0);
+  --destructive: oklch(0.6 0.2 20); /* #ff5555 */
+  --border: oklch(0.3 0.05 290);
+  --input: oklch(0.3 0.05 290);
+  --ring: oklch(0.68 0.16 320);
+  --sidebar: oklch(0.245 0.04 290);
+  --sidebar-foreground: oklch(0.965 0 0);
+  --sidebar-primary: oklch(0.68 0.16 320);
+  --sidebar-primary-foreground: oklch(0.245 0.04 290);
+  --sidebar-accent: oklch(0.3 0.05 290);
+  --sidebar-accent-foreground: oklch(0.965 0 0);
+  --sidebar-border: oklch(0.3 0.05 290);
+  --sidebar-ring: oklch(0.68 0.16 320);
+}
+
+/* Nord Theme */
+.nord {
+  --background: oklch(0.3 0.03 240); /* #2e3440 */
+  --foreground: oklch(0.9 0.02 240); /* #d8dee9 */
+  --card: oklch(0.33 0.03 240); /* #3b4252 */
+  --card-foreground: oklch(0.9 0.02 240);
+  --popover: oklch(0.33 0.03 240);
+  --popover-foreground: oklch(0.9 0.02 240);
+  --primary: oklch(0.65 0.05 220); /* #81a1c1 */
+  --primary-foreground: oklch(0.3 0.03 240);
+  --secondary: oklch(0.35 0.03 240); /* #434c5e */
+  --secondary-foreground: oklch(0.9 0.02 240);
+  --muted: oklch(0.35 0.03 240);
+  --muted-foreground: oklch(0.6 0.02 240); /* #4c566a */
+  --accent: oklch(0.35 0.03 240);
+  --accent-foreground: oklch(0.9 0.02 240);
+  --destructive: oklch(0.6 0.15 20); /* #bf616a */
+  --border: oklch(0.35 0.03 240);
+  --input: oklch(0.35 0.03 240);
+  --ring: oklch(0.65 0.05 220);
+  --sidebar: oklch(0.3 0.03 240);
+  --sidebar-foreground: oklch(0.9 0.02 240);
+  --sidebar-primary: oklch(0.65 0.05 220);
+  --sidebar-primary-foreground: oklch(0.3 0.03 240);
+  --sidebar-accent: oklch(0.35 0.03 240);
+  --sidebar-accent-foreground: oklch(0.9 0.02 240);
+  --sidebar-border: oklch(0.35 0.03 240);
+  --sidebar-ring: oklch(0.65 0.05 220);
+}
+
+/* Synthwave Theme */
+.synthwave {
+  --background: oklch(0.2 0.05 300); /* #241b2f */
+  --foreground: oklch(0.95 0.02 70); /* #f8f8f2 */
+  --card: oklch(0.25 0.05 300); /* #2a2139 */
+  --card-foreground: oklch(0.95 0.02 70);
+  --popover: oklch(0.25 0.05 300);
+  --popover-foreground: oklch(0.95 0.02 70);
+  --primary: oklch(0.65 0.25 340); /* #ff7edb */
+  --primary-foreground: oklch(0.2 0.05 300);
+  --secondary: oklch(0.3 0.05 300); /* #34294f */
+  --secondary-foreground: oklch(0.95 0.02 70);
+  --muted: oklch(0.3 0.05 300);
+  --muted-foreground: oklch(0.6 0.1 300); /* #8d85a0 */
+  --accent: oklch(0.3 0.05 300);
+  --accent-foreground: oklch(0.95 0.02 70);
+  --destructive: oklch(0.6 0.2 20); /* #fe4450 */
+  --border: oklch(0.3 0.05 300);
+  --input: oklch(0.3 0.05 300);
+  --ring: oklch(0.65 0.25 340);
+  --sidebar: oklch(0.2 0.05 300);
+  --sidebar-foreground: oklch(0.95 0.02 70);
+  --sidebar-primary: oklch(0.65 0.25 340);
+  --sidebar-primary-foreground: oklch(0.2 0.05 300);
+  --sidebar-accent: oklch(0.3 0.05 300);
+  --sidebar-accent-foreground: oklch(0.95 0.02 70);
+  --sidebar-border: oklch(0.3 0.05 300);
+  --sidebar-ring: oklch(0.65 0.25 340);
+}
+
+/* Github Light Theme */
+.github-light {
+  --background: oklch(0.99 0 0); /* #ffffff */
+  --foreground: oklch(0.25 0.01 240); /* #24292f */
+  --card: oklch(0.99 0 0);
+  --card-foreground: oklch(0.25 0.01 240);
+  --popover: oklch(0.99 0 0);
+  --popover-foreground: oklch(0.25 0.01 240);
+  --primary: oklch(0.45 0.15 240); /* #0969da */
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.95 0 0); /* #f6f8fa */
+  --secondary-foreground: oklch(0.25 0.01 240);
+  --muted: oklch(0.95 0 0);
+  --muted-foreground: oklch(0.45 0.01 240); /* #57606a */
+  --accent: oklch(0.95 0 0);
+  --accent-foreground: oklch(0.25 0.01 240);
+  --destructive: oklch(0.5 0.2 20); /* #cf222e */
+  --border: oklch(0.9 0 0); /* #d0d7de */
+  --input: oklch(0.9 0 0);
+  --ring: oklch(0.45 0.15 240);
+  --sidebar: oklch(0.95 0 0);
+  --sidebar-foreground: oklch(0.25 0.01 240);
+  --sidebar-primary: oklch(0.45 0.15 240);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.9 0 0);
+  --sidebar-accent-foreground: oklch(0.25 0.01 240);
+  --sidebar-border: oklch(0.9 0 0);
+  --sidebar-ring: oklch(0.45 0.15 240);
+}
+
+/* Github Dark Theme */
+.github-dark {
+  --background: oklch(0.15 0.01 240); /* #0d1117 */
+  --foreground: oklch(0.9 0.01 240); /* #c9d1d9 */
+  --card: oklch(0.18 0.01 240); /* #161b22 */
+  --card-foreground: oklch(0.9 0.01 240);
+  --popover: oklch(0.18 0.01 240);
+  --popover-foreground: oklch(0.9 0.01 240);
+  --primary: oklch(0.55 0.15 240); /* #58a6ff */
+  --primary-foreground: oklch(0.15 0.01 240);
+  --secondary: oklch(0.22 0.01 240); /* #21262d */
+  --secondary-foreground: oklch(0.9 0.01 240);
+  --muted: oklch(0.22 0.01 240);
+  --muted-foreground: oklch(0.6 0.01 240); /* #8b949e */
+  --accent: oklch(0.22 0.01 240);
+  --accent-foreground: oklch(0.9 0.01 240);
+  --destructive: oklch(0.6 0.2 20); /* #f85149 */
+  --border: oklch(0.3 0.01 240); /* #30363d */
+  --input: oklch(0.3 0.01 240);
+  --ring: oklch(0.55 0.15 240);
+  --sidebar: oklch(0.18 0.01 240);
+  --sidebar-foreground: oklch(0.9 0.01 240);
+  --sidebar-primary: oklch(0.55 0.15 240);
+  --sidebar-primary-foreground: oklch(0.15 0.01 240);
+  --sidebar-accent: oklch(0.22 0.01 240);
+  --sidebar-accent-foreground: oklch(0.9 0.01 240);
+  --sidebar-border: oklch(0.3 0.01 240);
+  --sidebar-ring: oklch(0.55 0.15 240);
+}
+
+/* -------------------------------------------------------------
+   ACCESSIBILITY OVERRIDES
+   ------------------------------------------------------------- */
+
+/* Text Scale */
+html[data-text-scale="small"] {
+  font-size: 14px;
+}
+html[data-text-scale="medium"] {
+  font-size: 16px;
+}
+html[data-text-scale="large"] {
+  font-size: 18px;
+}
+html[data-text-scale="xlarge"] {
+  font-size: 20px;
+}
+
+/* High Contrast Mode */
+html[data-high-contrast="true"] {
+  --foreground: oklch(0 0 0) !important;
+  --background: oklch(1 0 0) !important;
+  --border: oklch(0 0 0) !important;
+  --input: oklch(0 0 0) !important;
+  --ring: oklch(0 0 0) !important;
+  --muted-foreground: oklch(0 0 0) !important;
+}
+
+html[data-high-contrast="true"].dark,
+html[data-high-contrast="true"] .dark {
+  --foreground: oklch(1 0 0) !important;
+  --background: oklch(0 0 0) !important;
+  --border: oklch(1 0 0) !important;
+  --input: oklch(1 0 0) !important;
+  --ring: oklch(1 0 0) !important;
+  --muted-foreground: oklch(1 0 0) !important;
+}
+
+/* Reduce Motion */
+html[data-reduce-motion="true"] *,
+html[data-reduce-motion="true"] *::before,
+html[data-reduce-motion="true"] *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "./AuthContext"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/sonner"
 import SmoothScroll from "@/components/SmoothScroll" // Import the new component
+import { SettingsProvider } from "./SettingsContext"
 
 export const metadata: Metadata = {
   title: "NPMChat",
@@ -24,9 +25,12 @@ export default function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
+          themes={['light', 'dark', 'dracula', 'nord', 'synthwave', 'github-light', 'github-dark']}
         >
-          <AuthProvider>{children}</AuthProvider>
-          <Toaster richColors />
+          <SettingsProvider>
+            <AuthProvider>{children}</AuthProvider>
+            <Toaster richColors />
+          </SettingsProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/frontend/src/components/chat/ChatPanel.tsx
+++ b/frontend/src/components/chat/ChatPanel.tsx
@@ -9,6 +9,7 @@ import { TypingIndicator } from "./TypingIndicator"
 import EmojiPicker from "emoji-picker-react"
 import { ModeToggle } from "../ui/mode-toggle"
 import { Check, CheckCheck } from "lucide-react"
+import { SettingsDrawer } from "../ui/settings-drawer"
 
 function MessageTick({
   seen,
@@ -60,7 +61,7 @@ export default function ChatPanel({
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null)
   const [editedText, setEditedText] = useState("")
   const [showDeleteConfirm, setShowDeleteConfirm] = useState<string | null>(null)
-
+  const [showSettings, setShowSettings] = useState(false)
 
   const { typingUsers, handleTyping } = useTypingIndicator(
     selectedUser?._id || "",
@@ -266,7 +267,7 @@ export default function ChatPanel({
         <div className="flex justify-between w-full px-2">
           <div className="flex flex-col">
             <span
-              className="text-lg font-extrabold text-primary cursor-pointer hover:text-[#39ff14]"
+              className="text-lg font-extrabold text-primary cursor-pointer hover:text-[var(--color-neon-green)]"
               onClick={() => setShowUserDetails(true)}
               title="View profile"
             >
@@ -274,7 +275,7 @@ export default function ChatPanel({
             </span>
             <span
               className={`text-sm font-bold ${selectedUser && selectedUser.status === "online"
-                ? "text-[#39ff14]"
+                ? "text-[var(--color-neon-green)]"
                 : "text-gray-400"
                 }`}
             >
@@ -283,9 +284,20 @@ export default function ChatPanel({
                 : "offline"}
             </span>
           </div>
-          <ModeToggle />
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowSettings(true)}
+              className="p-2 rounded-full border-2 border-sidebar-border bg-accent hover:bg-[#b39ddb] focus:outline-none"
+              aria-label="Open settings"
+              title="Settings"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+            </button>
+            <ModeToggle />
+          </div>
         </div>
       </div>
+      <SettingsDrawer isOpen={showSettings} onClose={() => setShowSettings(false)} />
       {/* Messages */}
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-4 bg-[#f3e8ff] dark:bg-accent">
         {messages.map((msg: any, i: number) => {

--- a/frontend/src/components/ui/settings-drawer.tsx
+++ b/frontend/src/components/ui/settings-drawer.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+import React, { useState } from "react"
+import { useSettings } from "@/app/SettingsContext"
+import { useTheme } from "next-themes"
+import { X } from "lucide-react"
+
+export function SettingsDrawer({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean
+  onClose: () => void
+}) {
+  const { theme, setTheme } = useTheme()
+  const {
+    accentColor,
+    setAccentColor,
+    textScale,
+    setTextScale,
+    highContrast,
+    setHighContrast,
+    reduceMotion,
+    setReduceMotion,
+  } = useSettings()
+
+  const developerThemes = [
+    { value: "light", label: "Light" },
+    { value: "dark", label: "Dark" },
+    { value: "dracula", label: "Dracula" },
+    { value: "nord", label: "Nord" },
+    { value: "synthwave", label: "Synthwave / Cyberpunk" },
+    { value: "github-light", label: "Github Light" },
+    { value: "github-dark", label: "Github Dark" },
+  ]
+
+  const textScales = [
+    { value: "small", label: "Small" },
+    { value: "medium", label: "Medium" },
+    { value: "large", label: "Large" },
+    { value: "xlarge", label: "Extra Large" },
+  ]
+
+  return (
+    <>
+      {/* Backdrop */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 transition-opacity"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Drawer */}
+      <div
+        className={`fixed top-0 right-0 h-full w-80 bg-background border-l-2 border-sidebar-border shadow-2xl z-50 transform transition-transform duration-300 ease-in-out ${
+          isOpen ? "translate-x-0" : "translate-x-full"
+        } flex flex-col`}
+        role="dialog"
+        aria-label="Settings Drawer"
+        aria-expanded={isOpen}
+      >
+        <div className="flex items-center justify-between p-4 border-b-2 border-sidebar-border bg-card">
+          <h2 className="text-xl font-bold text-foreground">Settings</h2>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+            aria-label="Close settings"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-6">
+          {/* Theme Selector */}
+          <div className="space-y-2">
+            <label htmlFor="theme-select" className="block text-sm font-bold text-foreground">
+              Developer Theme
+            </label>
+            <select
+              id="theme-select"
+              value={theme}
+              onChange={(e) => setTheme(e.target.value)}
+              className="w-full p-2 border-2 border-sidebar-border rounded-md bg-input text-foreground focus:outline-none focus:border-ring"
+              aria-label="Select theme"
+            >
+              {developerThemes.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Custom Accent Color */}
+          <div className="space-y-2">
+            <label htmlFor="accent-color" className="block text-sm font-bold text-foreground">
+              Primary Accent Color
+            </label>
+            <div className="flex items-center gap-3">
+              <input
+                type="color"
+                id="accent-color"
+                value={accentColor}
+                onChange={(e) => setAccentColor(e.target.value)}
+                className="w-10 h-10 p-0 border-2 border-sidebar-border rounded-md cursor-pointer"
+                aria-label="Choose accent color"
+              />
+              <span className="text-sm font-mono text-muted-foreground">{accentColor}</span>
+            </div>
+          </div>
+
+          <div className="border-t-2 border-sidebar-border my-4" />
+
+          <h3 className="text-lg font-bold text-foreground">Accessibility (a11y)</h3>
+
+          {/* Text Scale */}
+          <div className="space-y-2">
+            <label htmlFor="text-scale" className="block text-sm font-bold text-foreground">
+              Text Scale
+            </label>
+            <input
+              type="range"
+              id="text-scale"
+              min="0"
+              max="3"
+              step="1"
+              value={textScales.findIndex((s) => s.value === textScale)}
+              onChange={(e) => setTextScale(textScales[parseInt(e.target.value)].value as any)}
+              className="w-full accent-primary"
+              aria-label="Adjust text scale"
+            />
+            <div className="flex justify-between text-xs text-muted-foreground mt-1">
+              {textScales.map((s) => (
+                <span key={s.value}>{s.label}</span>
+              ))}
+            </div>
+          </div>
+
+          {/* High Contrast Mode */}
+          <div className="flex items-center justify-between">
+            <label htmlFor="high-contrast" className="text-sm font-bold text-foreground">
+              High Contrast Mode
+            </label>
+            <input
+              type="checkbox"
+              id="high-contrast"
+              checked={highContrast}
+              onChange={(e) => setHighContrast(e.target.checked)}
+              className="w-5 h-5 accent-primary cursor-pointer border-2 border-sidebar-border rounded"
+              aria-label="Toggle high contrast mode"
+            />
+          </div>
+
+          {/* Reduce Motion */}
+          <div className="flex items-center justify-between">
+            <label htmlFor="reduce-motion" className="text-sm font-bold text-foreground">
+              Reduce Motion
+            </label>
+            <input
+              type="checkbox"
+              id="reduce-motion"
+              checked={reduceMotion}
+              onChange={(e) => setReduceMotion(e.target.checked)}
+              className="w-5 h-5 accent-primary cursor-pointer border-2 border-sidebar-border rounded"
+              aria-label="Toggle reduce motion"
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
# PR Description

## Related Issue

Closes #125

## Overview

This PR introduces a fully customizable Theme & Accessibility Settings Drawer for NPMChat to improve personalization, usability, and accessibility while preserving the platform’s Neo-Brutalist design language.

## Features Added

### Theme Customizer

* Added multiple predefined developer themes:

  * Dracula
  * Nord
  * Synthwave/Cyberpunk
  * GitHub Light
  * GitHub Dark

* Added dynamic accent color customization using CSS variables

* Implemented persistent theme storage using `localStorage`

### Accessibility (a11y) Enhancements

* Added text scaling options:

  * Small
  * Medium
  * Large
  * Extra Large

* Added High Contrast Mode for improved readability

* Added Reduce Motion toggle to disable animations/transitions

* Improved accessibility with proper ARIA labels and keyboard-friendly interactions

### Frontend Architecture

* Created a global `SettingsContext` / `ThemeProvider`
* Applied theme settings globally using `data-theme` and CSS custom properties
* Built an animated slide-out settings drawer
* Integrated Tailwind CSS + CSS variables for scalable theming

## Technical Details

* React Context API for global state management
* `useEffect` synchronization with `localStorage`
* CSS custom properties for dynamic styling
* Responsive and accessible UI implementation

## Screenshots

(Add screenshots/gifs here)

## Checklist

* [x] Theme persistence implemented
* [x] Accessibility controls added
* [x] Responsive UI tested
* [x] ARIA accessibility improvements included
* [x] Maintains Neo-Brutalist aesthetic
