### PR TITLE
fix: normalize email case during signup verification (#129)

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -103,7 +103,7 @@ export const signup = async (req, res) => {
           message: "Invalid email verification session.",
         })
       }
-      if (decoded.email !== email) {
+      if (decoded.email.toLowerCase() !== email.toLowerCase()) {
         return res.status(400).json({
           message: "Email verification session does not match this signup email.",
         })

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -97,7 +97,7 @@ describe("Auth Routes", () => {
 
     expect(res.status).toBe(201)
     expect(res.body.message).toBe("User created successfully.")
-    expect(res.body.user.email).toBe(emailUpper)
+    expect(res.body.user.email).toBe(emailUpper.toLowerCase())
   })
 
   it("POST /api/v1/auth/signup - should fail with missing fields", async () => {

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -75,6 +75,31 @@ describe("Auth Routes", () => {
     expect(res.body.message).toBe("User already exists.")
   })
 
+  it("POST /api/v1/auth/signup - should succeed even with case differences in email", async () => {
+    // Generate an OTP and verification token with lowercase email
+    const emailLower = "casetest@example.com"
+    const emailUpper = "CASETEST@example.com"
+    
+    const emailVerificationToken = jwt.sign(
+      { email: emailLower, type: "email-verification" },
+      process.env.JWT_SECRET || "test-secret",
+    )
+
+    // Attempt signup with uppercase email
+    const res = await request(app)
+      .post("/api/v1/auth/signup")
+      .send({
+        email: emailUpper,
+        password: "password123",
+        name: "Case Test User",
+        emailVerificationToken,
+      })
+
+    expect(res.status).toBe(201)
+    expect(res.body.message).toBe("User created successfully.")
+    expect(res.body.user.email).toBe(emailUpper)
+  })
+
   it("POST /api/v1/auth/signup - should fail with missing fields", async () => {
     const res = await request(app)
       .post("/api/v1/auth/signup")


### PR DESCRIPTION
## Description

Fixes #129

There was a logical casing mismatch in `backend/controllers/user.controller.js` during the signup process. When verifying the `emailVerificationToken`, the backend compared the `decoded.email` (from the JWT) with the `email` from the signup request payload using a strict equality check (`!==`). 

If a user started the OTP process using uppercase letters (e.g. `TEST@example.com`), the MongoDB schema for OTPs lowercased it, causing the JWT to be signed with `test@example.com`. However, when they submitted the signup form, the payload might still contain the uppercase email, causing the strict equality check to fail with:
> "Email verification session does not match this signup email."

## Changes Made
- Added `.toLowerCase()` to both sides of the email comparison in the `signup` controller function. This normalizes the casing before comparison and allows legitimate users to sign up without errors regardless of how they capitalized their email in the form.
- Added a new unit test `POST /api/v1/auth/signup - should succeed even with case differences in email` in `backend/tests/auth.test.js` to prevent regressions.

## GSSoC 2026
This PR is submitted as part of GSSoC 2026. Closes #129.
