### PR TITLE
fix: resolve TypeError in editMessage (fixes #138)

### DIFF
--- a/backend/controllers/message.controller.js
+++ b/backend/controllers/message.controller.js
@@ -186,15 +186,15 @@ export const editMessage = async (req, res) => {
 
     const message = await Message.findById(messageId)
 
-    if (message.deleted) {
-      return res.status(400).json({
-        message: "Deleted messages cannot be edited.",
-      })
-    }
-
     if (!message) {
       return res.status(404).json({
         message: "Message not found.",
+      })
+    }
+
+    if (message.deleted) {
+      return res.status(400).json({
+        message: "Deleted messages cannot be edited.",
       })
     }
 


### PR DESCRIPTION
## 📝 Pull Request Template

> Please complete all sections before submitting your PR. This helps
> reviewers understand the context and purpose of your changes.

---

## 📌 Description

_What does this PR do? Describe the purpose, changes made, and the problem it solves._

- Type: Bug Fix
- Summary: Solves the `TypeError` crash in `backend/controllers/message.controller.js` when attempting to edit or delete a message that does not exist. Checked for message existence before checking `message.deleted`.

---

## 🔗 Related Issues
> Reference related issues (use #issue_number)

- Closes #138

---

## ✅ Checklist

- [x] Code compiles and runs clean
- [ ] Added/Updated documentation
- [ ] Added/Updated tests
- [x] Linted and formatted code
- [x] Related issue linked
- [x] No sensitive data added

---

## 📸 Screenshots (if applicable)

N/A

---

## 💬 Notes for Reviewers

The fix correctly reorders the validation checks so that `Message.findById` returning `null` properly triggers a `404` instead of a `500 Internal Server Error`.

---

## 🧪 How to Test This PR

- Pull this branch
- Run npm run dev
- Send an edit request with an invalid message ID and confirm it returns a 404 instead of crashing the server.

---

## 📦 Tech Stack

- Node.js
- Express
- MongoDB
- Socket.IO
- React