### PR TITLE
fix: prevent duplicate Cloudinary avatar uploads on profile update

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -390,24 +390,26 @@ export const resetPassword = async (req, res) => {
 export const updateProfile = async (req, res) => {
   const { name, avatarUrl, bio } = req.body
   const userId = req.user._id // Assuming user ID is available in req.user
-  let updatedData
 
   try {
-    if (!avatarUrl) {
-      updatedData = await User.findByIdAndUpdate(
-        userId,
-        { name, bio },
-        { new: true },
-      )
-    } else {
-      const uploadedImage = await cloudinary.uploader.upload(avatarUrl)
+    const updateFields = { name, bio }
 
-      updatedData = await User.findByIdAndUpdate(
-        userId,
-        { name, avatarUrl: uploadedImage.secure_url, bio },
-        { new: true },
-      )
+    const nextAvatarUrl = (typeof avatarUrl === "string" ? avatarUrl : "").trim()
+    const currentAvatarUrl = (req.user?.avatarUrl || "").trim()
+
+    const shouldUploadNewAvatar =
+      nextAvatarUrl &&
+      nextAvatarUrl !== currentAvatarUrl &&
+      nextAvatarUrl.startsWith("data:")
+
+    if (shouldUploadNewAvatar) {
+      const uploadedImage = await cloudinary.uploader.upload(nextAvatarUrl)
+      updateFields.avatarUrl = uploadedImage.secure_url
     }
+
+    const updatedData = await User.findByIdAndUpdate(userId, updateFields, {
+      new: true,
+    })
 
     res.status(200).json({
       message: "Profile updated successfully.",

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -20,6 +20,7 @@ import {
   verifyOTPSchema,
   forgotPasswordSchema,
   resetPasswordSchema,
+  updateProfileSchema,
 } from "../schemas/user.schema.js"
 
 const userRouter = express.Router()
@@ -173,6 +174,11 @@ userRouter.get("/check-auth", protectRoute, checkAuth)
  *       500:
  *         description: Internal server error
  */
-userRouter.put("/update-profile", protectRoute, updateProfile)
+userRouter.put(
+  "/update-profile",
+  protectRoute,
+  validateBody(updateProfileSchema),
+  updateProfile,
+)
 
 export default userRouter

--- a/backend/schemas/user.schema.js
+++ b/backend/schemas/user.schema.js
@@ -65,3 +65,9 @@ export const verifyOTPSchema = z.object({
     .string({ required_error: "OTP is required" })
     .length(6, "OTP must be exactly 6 digits"),
 })
+
+export const updateProfileSchema = z.object({
+  name: z.string().trim().min(2).max(50).optional(),
+  bio: z.string().max(500).optional(),
+  avatarUrl: z.string().optional(),
+})

--- a/frontend/src/components/chat/ModernNPMChat.tsx
+++ b/frontend/src/components/chat/ModernNPMChat.tsx
@@ -37,7 +37,16 @@ const ChatPanels: React.FC<{ currentUser: any }> = ({ currentUser }) => {
   }
   async function handleProfileSave() {
     if (!profileDraft) return
-    await updateProfile(profileDraft)
+    const payload: Record<string, unknown> = {
+      name: profileDraft.name,
+      bio: profileDraft.bio,
+    }
+
+    if (profileDraft.avatarUrl !== user?.avatarUrl) {
+      payload.avatarUrl = profileDraft.avatarUrl
+    }
+
+    await updateProfile(payload)
     setShowProfile(false)
   }
   function handleLogout() {


### PR DESCRIPTION
## Summary

Fixes `updateProfile` so saving the profile no longer re-uploads an already-hosted Cloudinary `avatarUrl` as a new asset every time. The backend now uploads only when the client sends a new image payload (`data:` URL), and the frontend only includes `avatarUrl` in the request when it actually changed. Added request-body validation for the update profile route.

## Related issue

Closes #153

## Testing

- [x] I ran the relevant checks locally (`backend/.node_modules/.bin/vitest.cmd run`)
- [x] I verified the app still starts
- [x] I tested the affected flow end-to-end

## Notes

- This prevents duplicate Cloudinary assets and unnecessary storage/API costs caused by uploading a Cloudinary URL back into Cloudinary.
- Added `updateProfileSchema` validation to keep request payloads well-formed.