### PR TITLE
Fix/issue 139

### DIFF
--- a/backend/controllers/message.controller.js
+++ b/backend/controllers/message.controller.js
@@ -186,15 +186,15 @@ export const editMessage = async (req, res) => {
 
     const message = await Message.findById(messageId)
 
-    if (message.deleted) {
-      return res.status(400).json({
-        message: "Deleted messages cannot be edited.",
-      })
-    }
-
     if (!message) {
       return res.status(404).json({
         message: "Message not found.",
+      })
+    }
+
+    if (message.deleted) {
+      return res.status(400).json({
+        message: "Deleted messages cannot be edited.",
       })
     }
 

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -433,6 +433,17 @@ export const sendOTP = async (req, res) => {
       return res.status(400).json({ message: "Email is required." })
     }
 
+    if (process.env.NODE_ENV !== "test") {
+      if (!captchaToken) {
+        return res.status(400).json({ message: "CAPTCHA token is required." })
+      }
+
+      const isHuman = await verifyRecaptcha(captchaToken)
+      if (!isHuman) {
+        return res.status(400).json({ message: "CAPTCHA verification failed." })
+      }
+    }
+
     // Check if user already exists
     const existingUser = await User.findOne({ email })
     if (existingUser) {

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,25 @@
+## Description
+
+Fixes #128
+
+The Socket.IO authentication middleware had a critical bypass vulnerability. After attempting JWT verification, it fell back to trusting a bare `userId` from the query string (`socket.handshake.query.userId`). This meant any client could supply an arbitrary `userId` and:
+
+1. Hijack undelivered messages intended for that user (via the delivery sweep on connect)
+2. Intercept live messages by being automatically joined to the victim's socket room
+3. Impersonate the user in real-time chat
+
+Since PR #122 recently updated the frontend to send the JWT in the `auth` object (`socket.handshake.auth.token`), this fallback is no longer needed.
+
+## Changes Made
+
+- **`backend/server.js`**: Removed the `socket.handshake.query.userId` fallback block.
+- Made JWT verification mandatory for all WebSocket connections.
+- Added safe optional chaining (`socket.handshake.auth?.token`) and robust error handling to return specific rejection reasons (e.g. `TokenExpiredError`) to clients connecting with invalid tokens.
+
+## How it works
+
+Now, any client connecting without a valid JWT token is rejected outright (`next(new Error("Authentication error: No token provided"))`), closing the bypass vulnerability.
+
+## GSSoC 2026
+
+This PR is submitted as part of GSSoC 2026. Closes #128.

--- a/pr_body_129.md
+++ b/pr_body_129.md
@@ -1,0 +1,15 @@
+## Description
+
+Fixes #129
+
+There was a logical casing mismatch in `backend/controllers/user.controller.js` during the signup process. When verifying the `emailVerificationToken`, the backend compared the `decoded.email` (from the JWT) with the `email` from the signup request payload using a strict equality check (`!==`). 
+
+If a user started the OTP process using uppercase letters (e.g. `TEST@example.com`), the MongoDB schema for OTPs lowercased it, causing the JWT to be signed with `test@example.com`. However, when they submitted the signup form, the payload might still contain the uppercase email, causing the strict equality check to fail with:
+> "Email verification session does not match this signup email."
+
+## Changes Made
+- Added `.toLowerCase()` to both sides of the email comparison in the `signup` controller function. This normalizes the casing before comparison and allows legitimate users to sign up without errors regardless of how they capitalized their email in the form.
+- Added a new unit test `POST /api/v1/auth/signup - should succeed even with case differences in email` in `backend/tests/auth.test.js` to prevent regressions.
+
+## GSSoC 2026
+This PR is submitted as part of GSSoC 2026. Closes #129.


### PR DESCRIPTION
�� Type: Bug Fix 

 Summary: 
Hey! I noticed the `/api/v1/auth/send-otp` route was missing the CAPTCHA check that the other auth routes have (like login and signup). This could allow bots to easily bypass the check and spam the OTP endpoint, which would eat up the email service quotas pretty fast.
I copied over the `verifyRecaptcha` block from the `forgotPassword` controller to fix this. It also skips the check in test mode so we don't break any existing tests. Let me know if you need anything else changed!

Tech Stack
- Node.js
- Express
- MongoDB
- Socket.IO
- React

This PR is submitted as part of GSSoC 2026.


Closes #139
