### PR TITLE
fix: throw error for missing CLIENT_URL in production

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -387,6 +387,11 @@ export const forgotPassword = async (req, res) => {
     user.passwordResetUsedAt = null
     await user.save()
 
+    const isProd = process.env.NODE_ENV === "production"
+    if (!process.env.CLIENT_URL && isProd) {
+      console.error("CLIENT_URL must be set in production")
+      return res.status(500).json({ message: "Internal server error." })
+    }
     const baseUrl = process.env.CLIENT_URL || "http://localhost:3000"
     const resetUrl = `${baseUrl.replace(/\/$/, "")}/reset-password?token=${encodeURIComponent(rawToken)}`
     await sendPasswordResetEmail({ to: user.email, resetUrl })
@@ -444,7 +449,9 @@ export const updateProfile = async (req, res) => {
   try {
     const updateFields = { name, bio }
 
-    const nextAvatarUrl = (typeof avatarUrl === "string" ? avatarUrl : "").trim()
+    const nextAvatarUrl = (
+      typeof avatarUrl === "string" ? avatarUrl : ""
+    ).trim()
     const currentAvatarUrl = (req.user?.avatarUrl || "").trim()
 
     const shouldUploadNewAvatar =


### PR DESCRIPTION
This PR prevents the backend from dispatching dead password reset links in the event of a configuration error.

## Changes:

- Removed the blanket http://localhost:3000 fallback for baseUrl.
- Added an explicit check that returns a 500 Internal Server Error if CLIENT_URL is missing and NODE_ENV === "production".
- Retained the localhost fallback safely for local development only.

## Related Issue 
Closes  #191 