### PR TITLE
Refactor: Improve type safety and Header handling in fetcher.ts

### DIFF
--- a/frontend/src/app/fetcher.ts
+++ b/frontend/src/app/fetcher.ts
@@ -70,13 +70,13 @@ export async function fetcher<T = any>(
   base: "auth" | "messages" | "v1" = "messages",
   isRetry = false,
 ): Promise<T> {
-  const headers: any = {
-    "Content-Type": "application/json",
-    ...(options.headers || {}),
+  const headers = new Headers(options.headers)
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json")
   }
 
   const t = getToken()
-  if (t) headers["Authorization"] = `Bearer ${t}`
+  if (t) headers.set("Authorization", `Bearer ${t}`)
 
   const fetchOptions: RequestInit = {
     ...options,
@@ -162,12 +162,12 @@ export const api = {
     fetcher<T>(path, { method: "GET" }, base),
   post: <T = any>(
     path: string,
-    body?: any,
+    body?: unknown,
     base: "auth" | "messages" | "v1" = "messages",
   ) => fetcher<T>(path, { method: "POST", body: JSON.stringify(body) }, base),
   put: <T = any>(
     path: string,
-    body?: any,
+    body?: unknown,
     base: "auth" | "messages" | "v1" = "messages",
   ) => fetcher<T>(path, { method: "PUT", body: JSON.stringify(body) }, base),
   delete: <T = any>(


### PR DESCRIPTION
## Description
Closes #204 

This PR hardens the type safety within our core HTTP fetching utility (`frontend/src/app/fetcher.ts`). 

### Changes Made
- **Replaced `any` with `unknown`:** The `body` parameter in API wrappers now uses `unknown`, preventing permissive payload bypassing and ensuring robust type checking.
- **Native `Headers` Object:** Refactored the header construction logic. Previously, spreading `options.headers` into a `Record<string, string>` caused type conflicts with TypeScript and unreliability at runtime if a true `Headers` instance was passed. It now securely leverages the `new Headers()` API.

### Verification
- Verified that the TypeScript compiler no longer complains about `HeadersInit` assignment incompatibilities.
- The authentication token and `Content-Type` are correctly securely appended to the outgoing requests.
