### PR TITLE
Refactor: Integrate User interface and remove 'any' in ModernNPMChat.tsx

### DIFF
--- a/frontend/src/components/chat/ModernNPMChat.tsx
+++ b/frontend/src/components/chat/ModernNPMChat.tsx
@@ -38,7 +38,7 @@ const ChatPanels: React.FC<{ currentUser: User }> = ({ currentUser }) => {
   )
   const { user, logout, updateProfile } = useAuth()
 
-  function handleUserClick(u: any) {
+  function handleUserClick(u: User) {
     setSelectedUser(u)
     if (window.innerWidth < 768) setMobileView("chat")
   }
@@ -63,21 +63,25 @@ const ChatPanels: React.FC<{ currentUser: User }> = ({ currentUser }) => {
     try {
       logout()
       toast.success("Logged out successfully!")
-    } catch (err: any) {
-      toast.error(err.message || "Logout failed, Try again!")
+    } catch (err: unknown) {
+      toast.error(
+        err instanceof Error ? err.message : "Logout failed, Try again!",
+      )
     }
   }
 
   const filteredUsers = users
-    .filter((u: any) => u.name.toLowerCase().includes(search.toLowerCase()))
-    .map((u: any) => ({
+    .filter((u: User) =>
+      (u.name || "").toLowerCase().includes(search.toLowerCase()),
+    )
+    .map((u: User) => ({
       ...u,
       unread: unseenMessages[u._id || u.id] || 0,
     }))
 
   const currentSelectedUser = selectedUser
     ? users.find(
-        (user: any) =>
+        (user: User) =>
           (user._id || user.id) === (selectedUser._id || selectedUser.id),
       ) || selectedUser
     : null


### PR DESCRIPTION
## Description
Closes #210

This PR eliminates `any` types from the user state management logic in `ModernNPMChat.tsx`, replacing them with the strictly typed `User` interface.

### Changes Made
- **Interface Integration:** Updated `handleUserClick` and all user array iteration callbacks (`filter`, `map`, `find`) to correctly expect the `User` interface rather than `any`.
- **Safe Property Access:** Handled optional properties on the `User` model. Specifically, it ensures that `User.name` has a safe empty string fallback `(u.name || "")` before executing `.toLowerCase()`, preventing potential null-reference crashes when rendering the sidebar.

### Verification
- The user sidebar correctly renders and filters users via search without console errors.
- Clicking on a user updates the selected context accurately.
